### PR TITLE
dropped edition to 2021, handle luwen dep with git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 !src/**
 !assets/
 !assets/**
+!luwen/
+!.gitmodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "luwen"]
+	path = luwen
+	url = https://github.com/tenstorrent/luwen.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,14 +714,14 @@ dependencies = [
 
 [[package]]
 name = "luwen-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "luwen-if"
-version = "0.6.5"
+version = "0.7.11"
 dependencies = [
  "bincode",
  "bitfield-struct",
@@ -734,7 +734,6 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "protoc-bin-vendored",
  "rust-embed",
  "serde",
  "serde_json",
@@ -743,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "luwen-ref"
-version = "0.5.3"
+version = "0.7.11"
 dependencies = [
  "indicatif",
  "luwen-core",
@@ -1026,55 +1025,6 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "protoc-bin-vendored"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
-dependencies = [
- "protoc-bin-vendored-linux-aarch_64",
- "protoc-bin-vendored-linux-ppcle_64",
- "protoc-bin-vendored-linux-x86_32",
- "protoc-bin-vendored-linux-x86_64",
- "protoc-bin-vendored-macos-aarch_64",
- "protoc-bin-vendored-macos-x86_64",
- "protoc-bin-vendored-win32",
-]
-
-[[package]]
-name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
-
-[[package]]
-name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_32"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_64"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
-
-[[package]]
-name = "protoc-bin-vendored-macos-aarch_64"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
-
-[[package]]
-name = "protoc-bin-vendored-macos-x86_64"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
-
-[[package]]
-name = "protoc-bin-vendored-win32"
-version = "3.1.0"
-source = "git+https://github.com/TTDRosen/rust-protoc-bin-vendored?rev=3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6#3cf2dd3df18b0a864f896d2fedf7acbacf3ac2c6"
 
 [[package]]
 name = "quote"
@@ -1572,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "ttkmd-if"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bitfield-struct",
  "luwen-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tt-smi-rs"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 authors = ["Ludwig"]
 description = "TUI for monitoring Tenstorrent hardware - Rust implementation"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,18 @@ Options:
 
 ## Installation
 
+### Prerequisites
+- Rust 1.90+ 
+- protobuf compiler (`protoc`), required by `luwen-if`
+  - Arch: `sudo pacman -S protobuf`
+  - Ubuntu/Debian: `sudo apt-get install protobuf-compiler`
+
+### Building
+
 ```bash
+git clone --recursive https://github.com/gogopex/tt-smi-rs.git
+cd tt-smi-rs
+git submodule update --init --recursive
 cargo build --release
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,35 @@
+use std::process::Command;
+use std::path::Path;
+
 fn main() {
     let luwen_lib_path = "./luwen/target/release";
+    
+    let lib_name = if cfg!(target_os = "linux") {
+        "libluwencpp.so"
+    } else if cfg!(target_os = "macos") {
+        "libluwencpp.dylib"
+    } else {
+        panic!("Unsupported OS");
+    };
+    
+    let lib_full_path = format!("{}/{}", luwen_lib_path, lib_name);
+    
+    if !Path::new(&lib_full_path).exists() {
+        println!("cargo:warning=Building luwencpp library...");
+        
+        let output = Command::new("cargo")
+            .args(&["build", "--release", "-p", "luwencpp"])
+            .current_dir("./luwen")
+            .output()
+            .expect("Failed to build luwencpp");
+        
+        if !output.status.success() {
+            panic!("Failed to build luwencpp: {}", 
+                   String::from_utf8_lossy(&output.stderr));
+        }
+        
+        println!("cargo:warning=Successfully built luwencpp library");
+    }
 
     println!("cargo:rustc-link-search=native={luwen_lib_path}");
     println!("cargo:rustc-link-lib=dylib=luwencpp");


### PR DESCRIPTION
- dropped edition to 2021 (since I didn't use any unstable features anyway)
- tweaked build.rs to handle the luwen dependency 
- updated the readme to clear up the actual install steps